### PR TITLE
add: append forward slash to i18npath

### DIFF
--- a/lib/utils/parse.ts
+++ b/lib/utils/parse.ts
@@ -29,7 +29,7 @@ export async function parseTranslations(
     );
 
     glob(
-      i18nPath + '**/' + options.filePattern,
+      i18nPath + '/**/' + options.filePattern,
       (err: Error, files: string[]) => {
         if (err) {
           return reject(err);


### PR DESCRIPTION
Adding a forward slash to the i18npath will free the user from having to provide a path with a trailing forward slash.

[The example in the readme does not have a trailing forward slash.](/README.md@master?L=59#translation-module)